### PR TITLE
adding SQL parser example

### DIFF
--- a/example/sql_parser.ex
+++ b/example/sql_parser.ex
@@ -1,0 +1,93 @@
+defmodule Pegasus.Example.SqlParser do
+  @moduledoc """
+  A simple SQL parser.
+  """
+  require Pegasus
+  import NimbleParsec
+
+  @options [
+    # Tagged Productions
+    StatementSelect: [tag: :select],
+    SelectList: [tag: :select_list],
+    SelectTarget: [tag: :select_target],
+    StatementSubquery: [tag: :subquery],
+    Identifier: [tag: :identifier],
+    PredicateGroupBy: [tag: :group_by],
+
+    # Constants
+    ConstantInteger: [tag: :constant, collect: true],
+    ConstantString: [tag: :constant, collect: true],
+
+    # Tagged tokens are used as defined options on a node.
+    TokenDistinct: [tag: :distinct],
+
+    # Ignore Tokens
+    Spacing: [ignore: true],
+    TokenComma: [ignore: true],
+    TokenSemiColon: [ignore: true],
+    TokenOpenParen: [ignore: true],
+    TokenCloseParen: [ignore: true],
+    TokenSelect: [ignore: true],
+    TokenFrom: [ignore: true],
+    TokenGroupBy: [ignore: true],
+  ]
+
+  Pegasus.parser_from_string(
+    """
+    SQL <- Statement
+
+    Statement <- StatementSelect Spacing TokenSemiColon
+
+    StatementSelect <-
+      Spacing TokenSelect
+      (Spacing TokenDistinct Spacing)?
+      Spacing SelectList
+      Spacing TokenFrom
+      Spacing SelectTarget
+      (Spacing PredicateGroupBy)?
+
+    SelectList <- TokenStar / Sequence
+
+    SelectTarget <- Identifier / StatementSubquery
+
+    StatementSubquery <- TokenOpenParen StatementSelect TokenCloseParen
+
+    # Its probably better to use a new node but using this as an option
+    # is probably fine.
+    PredicateGroupBy <- TokenGroupBy Spacing Sequence
+
+    Sequence <- SequenceElement ( Spacing? TokenComma Spacing? Sequence )*
+
+    SequenceElement <- Identifier / ConstantString / ConstantInteger
+
+    Identifier      <- < IdentStart IdentCont* > Spacing
+    IdentStart      <- [a-zA-Z_]
+    IdentCont       <- IdentStart / [0-9]
+
+    # Tokens
+    TokenDistinct   <- < [Dd][Ii][Ss][Tt][Ii][Nn][Cc][Tt] >
+    TokenFrom       <- < [Ff][Rr][Oo][Mm] >
+    TokenGroupBy    <- < [Gg][Rr][Oo][Uu][Pp] > Spacing < [Bb][Yy] >
+    TokenSelect     <- < [Ss][Ee][Ll][Ee][Cc][Tt] >
+
+    TokenSemiColon  <- ";"
+    TokenComma      <- ","
+    TokenStar       <- "*"
+    TokenOpenParen  <- "("
+    TokenCloseParen <- ")"
+
+    # Constants
+    ConstantInteger <- [0-9]*
+    ConstantString  <- ['] < ( !['] . )* > [']
+
+    # Misc
+    Spacing         <- ( Space / Comment )*
+    Space           <- ' ' / '\t' / EndOfLine
+    Comment         <- '//' ( !EndOfLine . )* EndOfLine
+    EndOfLine       <- '\r\n' / '\n' / '\r'
+    """,
+    @options
+  )
+
+  defparsec :parse, parsec(:SQL)
+end

--- a/example/sql_parser.ex
+++ b/example/sql_parser.ex
@@ -1,4 +1,4 @@
-defmodule PgSuggester.Parser do
+defmodule Pegasus.Example.Parser do
   @moduledoc """
   Parses a SQL statement into a simplistic AST.
 
@@ -134,9 +134,9 @@ defmodule PgSuggester.Parser do
 
     ExpressionConstant <- 
       TokenDynamic
+      / ConstantString
       / Identifier
       / ConstantInteger
-      / ConstantString
 
     Identifier      <- < IdentStart IdentCont* > Spacing
     IdentStart      <- [a-zA-Z_\.]
@@ -177,6 +177,19 @@ defmodule PgSuggester.Parser do
   )
 
   defparsec(:parse, parsec(:SQL))
+
+  @doc "Prints the AST in a relativly reasonable format."
+  def print(ast) do
+    Logger.debug(inspect(ast, pretty: true, width: 150))
+  end
+
+  @doc """
+  Prints the AST in a relativly reasonable format with the line and file of the
+  caller.
+  """
+  def print(ast, file_caller, line_caller) do
+    Logger.debug("#{file_caller}:#{line_caller} #{inspect(ast, pretty: true, width: 150)}")
+  end
 
   # The generic post_traverser is a helper to form a generic node from a parse node.
   # This basically just flattens the parse node into a consistent AST structure.


### PR DESCRIPTION
Thank you for the library! This adds a simple incomplete SQL parser as an example.

```sql
SELECT i, 'a', 1 FROM asdf GROUP BY i;
```

Returns a simple Keyword list
```elixir
{:ok,
 [
   select: [
     select_list: [identifier: ["i"], constant: ["a"], constant: ["1"]],
     select_target: [identifier: ["asdf"]],
     group_by: [identifier: ["i"]]
   ]
 ], "", %{}, {1, 0}, 38}
```